### PR TITLE
Changed sort order of 'Definitions in this specification'

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The consumer perspective covers all topics on finding and using Angular componen
 
 ### Dependencies
 
-This specification also expects that needed tools are already installed and ready to use. 
+This specification also expects that needed tools are already installed and ready to use.
 Which means the following commands should be used to install the needed tools on a local machine:
 
 **Node Package Manager**
@@ -31,30 +31,30 @@ $ npm install -g bower
 
 ### Definitions in this specification
 
-This specification contains expressions like _modules_, _components_ and _packages_. 
+This specification contains expressions like _components_, _packages_ and _modules_.
 These are the definitions:
-
-#### Package
-_Package_ is a Bower concept. 
-For the time being,  one can think of the terms _package_ and _component_ as being interchangeable in the context of Bower. 
-In general, _package_ is the thing that you can download, and contains a _component_, which is a group of one or more assets. 
-Saying one can think of them as interchangeable for now, is because there's a one-to-one correspondence of package to component.
 
 #### Component
 _Component_ is a Bower concept.
-A _component_ is a repo which contains some files for client-side use in a web browser. 
-This may include, but is not limited to, JavaScript, CSS, HTML, and images. 
+A _component_ is a repo which contains some files for client-side use in a web browser.
+This may include, but is not limited to, JavaScript, CSS, HTML, and images.
 A Bower _component_ has a component.json (or bower.json) file that describes the _component_ and its dependencies.
 
+#### Package
+_Package_ is a Bower concept.
+For the time being,  one can think of the terms _package_ and _component_ as being interchangeable in the context of Bower.
+In general, _package_ is the thing that you can download, and contains a _component_, which is a group of one or more assets.
+Saying one can think of them as interchangeable for now, is because there's a one-to-one correspondence of package to component.
+
 #### Module
-When the word _module_ appears, this specification means an AngularJS module. 
-An AngularJS Module may have multiple directives, services, or filters. 
-For _components_, each _module_ typically has its own file. 
+When the word _module_ appears, this specification means an AngularJS module.
+An AngularJS module may have multiple directives, services, or filters.
+For _components_, each _module_ typically has its own file.
 Bower _components_ typically contain just one AngularJS _module_, though in theory there can be more.
 
 ## AngularJS Components Consumer
 
-_This part of the **Reusable AngularJS components** specification is highly inspired by @btford 's [blog post](http://briantford.com/blog/angular-bower.html)._ 
+_This part of the **Reusable AngularJS components** specification is highly inspired by @btford 's [blog post](http://briantford.com/blog/angular-bower.html)._
 
 ### Table Of Contents
 
@@ -106,8 +106,8 @@ $ bower search angular
 Should return a list of registered bower packages with an _angular_ in their name.
 
 #### Finding packages with keywords
-Bower doesn't currently support a search with keywords. 
-Filtering packages by keyboard can be done by using <code>bower search</code> in combination with the <code>grep</code> command. 
+Bower doesn't currently support a search with keywords.
+Filtering packages by keyboard can be done by using <code>bower search</code> in combination with the <code>grep</code> command.
 So the following command searches for Angular packages with the keyword "phonegap".
 
 ````
@@ -115,7 +115,7 @@ $ bower search angular | grep "phonegap"
 ````
 
 ### Installing packages
-Once the right package is found, one can install it using the Bower <code>install</code> command. 
+Once the right package is found, one can install it using the Bower <code>install</code> command.
 E.g. installing AngularJS itself as a package would look like this:
 
 ````
@@ -125,15 +125,15 @@ $ bower install angular
 This will download the specified package into the folder which is configured as components folder via <code>.bowerrc</code>.
 
 #### Installing unregistered packages
-It is possible that there's an AngularJS component on GitHub, which is not registered as bower component. 
+It is possible that there's an AngularJS component on GitHub, which is not registered as bower component.
 This could have several reasons:
 
 * The author doesn't plan to publish it as a Bower component
 * The name the author wants to register it is already been taken
-* The package is actually registered but the endpoint is broken (which unfortunately happens often, and there's currently no way to take care of that as a package maintainer. 
+* The package is actually registered but the endpoint is broken (which unfortunately happens often, and there's currently no way to take care of that as a package maintainer.
 See [https://github.com/twitter/bower/issues/120](https://github.com/twitter/bower/issues/120)
 
-In that cases one can install the package by specifying the GitHub user and the repository. 
+In that cases one can install the package by specifying the GitHub user and the repository.
 This works for **every** GitHub repository.
 
 ````


### PR DESCRIPTION
Hi all,

I find it more natural to sort the 'Definitions in this specification' in the order 'Component', 'Package', 'Module', since 'Package' refers to 'Component'.
